### PR TITLE
Fixed issue across API when generating JSON. Previously, if an attrib…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,21 @@
       <version>${junit.vintage.version}</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+          <version>8.0.30</version>
+      </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>8.0.30</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>8.0.30</version>
+    </dependency>
   </dependencies>
   <properties>
     <java.version>1.8</java.version>

--- a/src/main/java/com/upcloud/client/models/AddressFamily.java
+++ b/src/main/java/com/upcloud/client/models/AddressFamily.java
@@ -55,7 +55,11 @@ public enum AddressFamily {
   public static class Adapter extends TypeAdapter<AddressFamily> {
     @Override
     public void write(final JsonWriter jsonWriter, final AddressFamily enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      if (enumeration != null) {
+        jsonWriter.value(enumeration.getValue());
+      } else {
+        jsonWriter.nullValue();
+      }
     }
 
     @Override

--- a/src/main/java/com/upcloud/client/models/BackupRule.java
+++ b/src/main/java/com/upcloud/client/models/BackupRule.java
@@ -74,7 +74,11 @@ public class BackupRule {
     public static class Adapter extends TypeAdapter<IntervalEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final IntervalEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override

--- a/src/main/java/com/upcloud/client/models/ErrorCode.java
+++ b/src/main/java/com/upcloud/client/models/ErrorCode.java
@@ -159,7 +159,11 @@ public enum ErrorCode {
   public static class Adapter extends TypeAdapter<ErrorCode> {
     @Override
     public void write(final JsonWriter jsonWriter, final ErrorCode enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      if (enumeration != null) {
+        jsonWriter.value(enumeration.getValue());
+      } else {
+        jsonWriter.nullValue();
+      }
     }
 
     @Override

--- a/src/main/java/com/upcloud/client/models/ErrorStatus.java
+++ b/src/main/java/com/upcloud/client/models/ErrorStatus.java
@@ -61,7 +61,11 @@ public enum ErrorStatus {
   public static class Adapter extends TypeAdapter<ErrorStatus> {
     @Override
     public void write(final JsonWriter jsonWriter, final ErrorStatus enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      if (enumeration != null) {
+        jsonWriter.value(enumeration.getValue());
+      } else {
+        jsonWriter.nullValue();
+      }
     }
 
     @Override

--- a/src/main/java/com/upcloud/client/models/FirewallRule.java
+++ b/src/main/java/com/upcloud/client/models/FirewallRule.java
@@ -62,7 +62,11 @@ public class FirewallRule {
     public static class Adapter extends TypeAdapter<DirectionEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final DirectionEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -84,7 +88,7 @@ public class FirewallRule {
     ACCEPT("accept"),
     
     REJECT("reject"),
-    
+
     DROP("drop");
 
     private String value;
@@ -114,7 +118,11 @@ public class FirewallRule {
     public static class Adapter extends TypeAdapter<ActionEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final ActionEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -172,7 +180,11 @@ public class FirewallRule {
     public static class Adapter extends TypeAdapter<ProtocolEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final ProtocolEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override

--- a/src/main/java/com/upcloud/client/models/IpAddress.java
+++ b/src/main/java/com/upcloud/client/models/IpAddress.java
@@ -62,7 +62,11 @@ public class IpAddress {
     public static class Adapter extends TypeAdapter<AccessEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final AccessEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -115,7 +119,11 @@ public class IpAddress {
     public static class Adapter extends TypeAdapter<FamilyEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final FamilyEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -171,7 +179,11 @@ public class IpAddress {
     public static class Adapter extends TypeAdapter<PartOfPlanEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final PartOfPlanEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override

--- a/src/main/java/com/upcloud/client/models/RestartServer.java
+++ b/src/main/java/com/upcloud/client/models/RestartServer.java
@@ -61,7 +61,11 @@ public class RestartServer {
     public static class Adapter extends TypeAdapter<StopTypeEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final StopTypeEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -114,7 +118,11 @@ public class RestartServer {
     public static class Adapter extends TypeAdapter<TimeoutActionEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final TimeoutActionEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override

--- a/src/main/java/com/upcloud/client/models/Server.java
+++ b/src/main/java/com/upcloud/client/models/Server.java
@@ -71,7 +71,11 @@ public class Server {
     public static class Adapter extends TypeAdapter<BootOrderEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final BootOrderEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -124,7 +128,11 @@ public class Server {
     public static class Adapter extends TypeAdapter<FirewallEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final FirewallEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -219,7 +227,11 @@ public class Server {
     public static class Adapter extends TypeAdapter<VideoModelEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final VideoModelEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -269,7 +281,11 @@ public class Server {
     public static class Adapter extends TypeAdapter<VncEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final VncEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override
@@ -333,7 +349,11 @@ public class Server {
     public static class Adapter extends TypeAdapter<PasswordDeliveryEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final PasswordDeliveryEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override

--- a/src/main/java/com/upcloud/client/models/ServerState.java
+++ b/src/main/java/com/upcloud/client/models/ServerState.java
@@ -60,7 +60,11 @@ public enum ServerState {
   public static class Adapter extends TypeAdapter<ServerState> {
     @Override
     public void write(final JsonWriter jsonWriter, final ServerState enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      if (enumeration != null) {
+        jsonWriter.value(enumeration.getValue());
+      } else {
+        jsonWriter.nullValue();
+      }
     }
 
     @Override

--- a/src/main/java/com/upcloud/client/models/StopServerRequest.java
+++ b/src/main/java/com/upcloud/client/models/StopServerRequest.java
@@ -62,7 +62,11 @@ public class StopServerRequest {
     public static class Adapter extends TypeAdapter<StopTypeEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final StopTypeEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override

--- a/src/main/java/com/upcloud/client/models/StorageAccessType.java
+++ b/src/main/java/com/upcloud/client/models/StorageAccessType.java
@@ -56,7 +56,11 @@ public enum StorageAccessType {
   public static class Adapter extends TypeAdapter<StorageAccessType> {
     @Override
     public void write(final JsonWriter jsonWriter, final StorageAccessType enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      if (enumeration != null) {
+        jsonWriter.value(enumeration.getValue());
+      } else {
+        jsonWriter.nullValue();
+      }
     }
 
     @Override

--- a/src/main/java/com/upcloud/client/models/StorageDevice.java
+++ b/src/main/java/com/upcloud/client/models/StorageDevice.java
@@ -76,7 +76,11 @@ public class StorageDevice {
     public static class Adapter extends TypeAdapter<PartOfPlanEnum> {
       @Override
       public void write(final JsonWriter jsonWriter, final PartOfPlanEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
+        if (enumeration != null) {
+          jsonWriter.value(enumeration.getValue());
+        } else {
+          jsonWriter.nullValue();
+        }
       }
 
       @Override

--- a/src/main/java/com/upcloud/client/models/StorageState.java
+++ b/src/main/java/com/upcloud/client/models/StorageState.java
@@ -62,7 +62,11 @@ public enum StorageState {
   public static class Adapter extends TypeAdapter<StorageState> {
     @Override
     public void write(final JsonWriter jsonWriter, final StorageState enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      if (enumeration != null) {
+        jsonWriter.value(enumeration.getValue());
+      } else {
+        jsonWriter.nullValue();
+      }
     }
 
     @Override

--- a/src/main/java/com/upcloud/client/models/StorageTier.java
+++ b/src/main/java/com/upcloud/client/models/StorageTier.java
@@ -56,7 +56,11 @@ public enum StorageTier {
   public static class Adapter extends TypeAdapter<StorageTier> {
     @Override
     public void write(final JsonWriter jsonWriter, final StorageTier enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      if (enumeration != null) {
+        jsonWriter.value(enumeration.getValue());
+      } else {
+        jsonWriter.nullValue();
+      }
     }
 
     @Override

--- a/src/main/java/com/upcloud/client/models/StorageType.java
+++ b/src/main/java/com/upcloud/client/models/StorageType.java
@@ -62,7 +62,11 @@ public enum StorageType {
   public static class Adapter extends TypeAdapter<StorageType> {
     @Override
     public void write(final JsonWriter jsonWriter, final StorageType enumeration) throws IOException {
-      jsonWriter.value(enumeration.getValue());
+      if (enumeration != null) {
+        jsonWriter.value(enumeration.getValue());
+      } else {
+        jsonWriter.nullValue();
+      }
     }
 
     @Override


### PR DESCRIPTION
…ute was not set, and thus an enum had a value of null (which is likely, as not all fields are required for all requests), a Bad Request: UNKNOWN_ATTRIBUTE response was thrown by the server.